### PR TITLE
Added import Graphics.Gloss.Data.Bitmap, required to work with Gloss 1.9...

### DIFF
--- a/Graphics/Gloss/Juicy.hs
+++ b/Graphics/Gloss/Juicy.hs
@@ -21,6 +21,7 @@ where
 import Codec.Picture
 import Codec.Picture.Types
 import Graphics.Gloss.Data.Picture
+import Graphics.Gloss.Data.Bitmap
 import Data.Vector.Storable        (unsafeToForeignPtr)
 
 -- | Tries to convert a 'DynamicImage' from JuicyPixels to a gloss 'Picture'.  All formats except RGBF and YF should successfully


### PR DESCRIPTION
To make gloss-juicy compiler and work correctly with Gloss version 1.9.2.1 a change to add the import:

import Graphics.Gloss.Data.Bitmap

was required, as this is now where bitmapOfForeignPtr is defined and exported.
