### PR TITLE
Update to use Gloss 1.10

### DIFF
--- a/Graphics/Gloss/Juicy.hs
+++ b/Graphics/Gloss/Juicy.hs
@@ -35,22 +35,11 @@ fromDynamicImage (ImageYCbCr8 img) = Just $ fromImageYCbCr8 img
 fromDynamicImage (ImageRGBF _)     = Nothing
 fromDynamicImage (ImageYF _)       = Nothing
 
--- Courtesy of Vincent Berthoux, JuicyPixels' author
--- bmp (and thus gloss) starts by the lines at the bottom
--- JuicyPixels does the converse
-horizontalSwap :: Image PixelRGBA8 -> Image PixelRGBA8
-horizontalSwap img@(Image { imageWidth = w, imageHeight = h }) =
-    generateImage swapper w h
-      where swapper x y = PixelRGBA8 a b g r
-                where PixelRGBA8 r g b a = pixelAt img x (h - y - 1)
-{-# INLINE horizontalSwap #-}
-
 -- | O(N) conversion from 'PixelRGBA8' image to gloss 'Picture', where N is the number of pixels.
 fromImageRGBA8 :: Image PixelRGBA8 -> Picture
 fromImageRGBA8 img@(Image { imageWidth = w, imageHeight = h, imageData = _ }) =
-  bitmapOfForeignPtr w h ptr True
-    where swapedImage = horizontalSwap img
-          (ptr, _, _) = unsafeToForeignPtr $ imageData swapedImage
+        bitmapOfForeignPtr w h (BitmapFormat TopToBottom PxRGBA) ptr True
+    where (ptr, _, _) = unsafeToForeignPtr (imageData img)
 {-# INLINE fromImageRGBA8 #-}
 
 -- | Creation of a gloss 'Picture' by promoting (through 'promoteImage') the 'PixelRGB8' image to 'PixelRGBA8' and calling 'fromImageRGBA8'.

--- a/gloss-juicy.cabal
+++ b/gloss-juicy.cabal
@@ -1,5 +1,5 @@
 name:                gloss-juicy
-version:             0.2
+version:             0.2.1
 synopsis:            Load any image supported by Juicy.Pixels in your gloss application
 description:         Lets you convert any image supported by Juicy.Pixels in a gloss application by converting to gloss' Bitmap representation.
 		     .
@@ -20,7 +20,7 @@ library
   build-depends:       base >=4 && < 5,
                        bytestring,
                        bmp >= 1.2.4.1,
-                       gloss >= 1.8,
+                       gloss >= 1.10,
                        JuicyPixels,
                        vector
   ghc-options:         -O2 -Wall -threaded
@@ -30,7 +30,7 @@ executable gloss-juicy-viewer
   build-depends:       base >= 4 && < 5,
                        bytestring,
                        bmp >= 1.2.4.1,
-                       gloss,
+                       gloss >= 1.10,
                        JuicyPixels,
                        vector
   ghc-options:         -O2 -Wall -threaded


### PR DESCRIPTION
The gloss pull request benl23x5/gloss#21 changes the API in a way that
allows us to skip the color channel and row re-ordering.  This is
significant because we no longer need to perform an O(N) copy of every
image, and instead propagate the row and pixel information to the
underlying OpenGL system (which can then do any number of things, but
whatever it does will probably be better optimized).

I'm hoping to get this merged at or near the merging of the gloss patch.  If you want we can do some CPP to accept a wider range of Gloss versions, but that solution always bothers me as hackish so I try to avoid it when the result seems acceptable.